### PR TITLE
#161 Migrate workflows to centralized SDK version matrix and fix job outputs

### DIFF
--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -12,8 +12,6 @@ permissions: {}
 
 jobs:
   pylint:
-    outputs:
-      status: ${{ job.status }}
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -49,10 +47,10 @@ jobs:
 
   slack-notification:
     needs: [pylint]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.pylint.outputs.status ) && github.ref_name == github.event.repository.default_branch }}
+    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.pylint.result ) && github.ref_name == github.event.repository.default_branch }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
-      job-status: ${{ needs.pylint.outputs.status }}
+      job-status: ${{ needs.pylint.result }}


### PR DESCRIPTION
## Summary

- Migrate hardcoded `senzingsdk-version` matrix entries to use centralized `senzing-factory/build-resources/sdk-versions@v4` composite action
- Remove deprecated `outputs: status: ${{ job.status }}` blocks from jobs
- Replace `.outputs.status` references with `.result` in slack notification jobs
- Fix `.claude/settings.json`

## Test plan

- [ ] Verify `sdk-versions` job runs and provides correct matrix values
- [ ] Verify test/build jobs receive matrix values via `fromJSON()`
- [ ] Verify slack notifications use `.result` correctly

---

Resolves #161